### PR TITLE
Add basic Python-related entries to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+__pycache__/
+.env
+*.pyc
+*.parquet
+cache/


### PR DESCRIPTION
## Summary
- add `.gitignore` with typical Python artifacts such as `__pycache__/` and `.pyc` files
- ignore environment files, parquet data, and cache directory

## Testing
- `git status --short`