### PR TITLE
Switch refresh script to logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,4 +30,17 @@ Execute:
 ```bash
 python refresh.py
 ```
-The script prints a table of the top edges and a JSON block with the same data.
+The script logs a table of the top edges and a JSON block with the same data.
+
+### Log levels
+
+Adjust the verbosity with the `LOG_LEVEL` environment variable or the
+`--log-level` command line option. Valid levels are the standard Python logging
+levels such as `DEBUG`, `INFO` and `WARNING`.
+
+Examples:
+
+```bash
+LOG_LEVEL=DEBUG python refresh.py          # via environment variable
+python refresh.py --log-level WARNING      # via CLI option
+```

--- a/refresh.py
+++ b/refresh.py
@@ -8,6 +8,9 @@ Output:   Top 10 player-points edges (table + JSON)
 
 import os, joblib, requests, pandas as pd
 import re
+import logging
+import argparse
+import sys
 from datetime import datetime, timezone
 from dotenv import load_dotenv
 
@@ -148,17 +151,27 @@ def main():
     top = df.sort_values("edge", ascending=False).head(10)
 
     # markdown
-    print(top[["player","game","prop","μ","edge","conf"]]
-          .to_markdown(index=False, floatfmt=".1f"))
+    logging.info("\n%s",
+                 top[["player","game","prop","μ","edge","conf"]]
+                 .to_markdown(index=False, floatfmt=".1f"))
 
     # JSON
-    print("\n```json")
-    print(top.to_json(orient="records", indent=2))
-    print("```")
+    logging.info("\n```json\n%s\n```",
+                 top.to_json(orient="records", indent=2))
 
     ts = datetime.now(timezone.utc).isoformat(timespec="seconds")
-    print(f"\nData refreshed: {ts} UTC")
-    print("\nPredictions are for informational purposes only. Bet responsibly.")
+    logging.info("\nData refreshed: %s UTC", ts)
+    logging.info("\nPredictions are for informational purposes only. Bet responsibly.")
 
 if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--log-level",
+                        default=os.getenv("LOG_LEVEL", "INFO"),
+                        help="Logging level (DEBUG, INFO, WARNING, ERROR)")
+    args = parser.parse_args()
+
+    logging.basicConfig(level=getattr(logging, args.log_level.upper(), logging.INFO),
+                        format="%(levelname)s: %(message)s",
+                        stream=sys.stdout)
+
     main()


### PR DESCRIPTION
## Summary
- replace `print` calls with Python `logging`
- configure root logger via CLI or LOG_LEVEL env
- document log level options in README

## Testing
- `python -m py_compile refresh.py`