### PR TITLE
Add caching for live props

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@
 
 Execute:
 ```bash
-python refresh.py
+python refresh.py [--refresh]
 ```
-The script prints a table of the top edges and a JSON block with the same data.
+Results are cached in `cache/live_props.json` keyed by date. Use `--refresh` to
+ignore the cache and fetch new odds. The script prints a table of the top edges
+and a JSON block with the same data.


### PR DESCRIPTION
## Summary
- cache Odds API results to `cache/live_props.json`
- add `--refresh` flag to ignore cache
- mention the new flag in the README

## Testing
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement joblib)*