### PR TITLE
Add rebounds & assists prop fetch

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # NBA Prop Pipeline
 
 `refresh.py` fetches NBA player prop odds from the Odds API and scores them with a trained regression model.
+It now collects rebound and assist markets in addition to points, though predictions
+are still generated for points only.
 
 ## Setup
 


### PR DESCRIPTION
## Summary
- extend API helpers to support rebounds and assists props
- pull these extra markets in `fetch_live_props`
- keep predictions restricted to the points market
- document new behaviour in README

## Testing
- `pytest -q` *(fails: command not found)*